### PR TITLE
feat: Add command-line argument for test type selection

### DIFF
--- a/debug_assistant_latest/main.py
+++ b/debug_assistant_latest/main.py
@@ -92,14 +92,24 @@ def run( debugType, configFile ):
 
 if __name__ == "__main__":
     if (len(sys.argv) < 2):
-        print ('config file not provided')
+        print('Usage: python3 main.py <config_file> [test_type]')
+        print('Available test types: allStepsAtOnce, stepByStep, singleAgent (default: allStepsAtOnce)')
         sys.exit(1)
 
     configFile = sys.argv[1]
+    
+    # Get test type from second argument, default to "allStepsAtOnce"
+    testType = sys.argv[2] if len(sys.argv) > 2 else "allStepsAtOnce"
+    
+    # Validate test type
+    validTestTypes = ["allStepsAtOnce", "stepByStep", "singleAgent"]
+    if testType not in validTestTypes:
+        print(f'Invalid test type: {testType}')
+        print(f'Available test types: {", ".join(validTestTypes)}')
+        sys.exit(1)
+    
     if os.path.exists(configFile):
-        run("allStepsAtOnce", configFile)
-        #run("singleAgent", configFile)
-        #run("stepByStep", configFile)
+        run(testType, configFile)
     else:
         print (f'{configFile} does not exist')
 


### PR DESCRIPTION
- Added optional third argument to specify test type (allStepsAtOnce, stepByStep, singleAgent)
- Maintained full backward compatibility with existing usage patterns
- Defaults to 'allStepsAtOnce' when no test type is specified
- Added comprehensive argument validation with helpful error messages
- Improved dev experience by eliminating need to manually comment/uncomment lines

Usage:
- python3 main.py config.json (uses default allStepsAtOnce)
- python3 main.py config.json stepByStep
- python3 main.py config.json singleAgent

Resolves the inefficient manual code editing workflow for test type selection.